### PR TITLE
add requestData() to MediaRecorder

### DIFF
--- a/src/factories/media-recorder-constructor.ts
+++ b/src/factories/media-recorder-constructor.ts
@@ -224,6 +224,10 @@ export const createMediaRecorderConstructor: TMediaRecorderConstructorFactory = 
             return this._internalMediaRecorder.stop();
         }
 
+        public requestData(): void {
+            return this._internalMediaRecorder.requestData();
+        }
+
         public static isTypeSupported(mimeType: string): boolean {
             return (
                 (nativeMediaRecorderConstructor !== null &&

--- a/src/interfaces/media-recorder.ts
+++ b/src/interfaces/media-recorder.ts
@@ -26,4 +26,6 @@ export interface IMediaRecorder extends IEventTarget<IMediaRecorderEventMap> {
     start(timeslice?: number): void;
 
     stop(): void;
+
+    requestData(): void;
 }


### PR DESCRIPTION
Closes #679

Simple passthrough like the other MediaRecorder functions.

If there's any reason to not do this or anything you'd like me to add let me know!